### PR TITLE
guards on buffer/config

### DIFF
--- a/hexy.js
+++ b/hexy.js
@@ -127,13 +127,15 @@
 (function (arg) {
 
 var hexy = function (buffer, config) {
-  config = config || {}
   var h = new Hexy(buffer, config)
   return h.toString()
 }
 
 var Hexy = function (buffer, config) {
   var self = this
+
+  buffer = (Buffer.isBuffer(buffer) && buffer) || (typeof buffer === 'string' && new Buffer(buffer)) || new Buffer(0)
+  config = config || {}
  
   self.buffer    = buffer // magic string conversion here?
   self.width     = config.width || 16


### PR DESCRIPTION
Using undefined as a buffer leads to the following error:

[...]/hexy/hexy.js:250
    for (var i = 0; i<self.buffer.length ; i+=self.width) {
                                 ^
TypeError: Cannot read property 'length' of undefined

I've added a guard on the buffer object and moved the guard for config from hexy to Hexy in order to centralize it.
Let me know if it works for you. As far as I understood, only Buffers and strings should be accepted. Is it?

Thank you,
Michele
