### PR TITLE
change "256n" BigInt literal to "BigInt(256)"

### DIFF
--- a/hexy.js
+++ b/hexy.js
@@ -387,7 +387,7 @@ var Hexy = function(buffer, config) {
         if (bytes_per_group < 4) {
           val = val * 256 + ((buffer.constructor == String ? buffer.codePointAt(i) : buffer[i]) & 0xff)
         } else {
-          val = BigInt(val) * 256n + BigInt(((buffer.constructor == String ? buffer.codePointAt(i) : buffer[i]) & 0xff))
+          val = BigInt(val) * BigInt(256) + BigInt(((buffer.constructor == String ? buffer.codePointAt(i) : buffer[i]) & 0xff))
         }
       }
       const text = val.toString(radix)


### PR DESCRIPTION
Thanks for the great work on this library!

I am using it on a project which I recently converted to [vite](vitejs.dev/).

I tried to use the [@vitejs/plugin-legacy](https://www.npmjs.com/package/@vitejs/plugin-legacy) plugin, but it is failing to build due to the `256n` usage in this library. A `vite build` fails with:
```
ERROR: Big integer literals are not available in the configured target environment
```
See a discussion here: https://github.com/vitejs/vite/discussions/13599

The following code change should fix my issue (if a new version of `hexy` is published).

Thanks again!