### PR TITLE
issue #24 -- misaligned last line and incorrectly displayed dangling byte(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 [![build status](https://api.travis-ci.com/a2800276/hexy.js.svg)](https://app.travis-ci.com/github/a2800276/hexy.js)
 
- # hexy.js -- utility to create hex dumps 
- 
- `hexy` is an easy to use javascript library to create hex dumps. It
- works just as well in node as in your browser. It contains a
- number of options to configure how the hex dump will end up looking.
- 
- It creates a pleasant looking hex dump by default:
-     
+hexy.js -- utility to create hex dumps
+
+# Usage
+`hexy` is an easy to use javascript library to create hex dumps. It works just as well in node as in your browser. It contains a number of options to configure how the hex dump will end up looking.
+
+It creates a pleasant looking hex dump by default:
 ```javascript     
 var hexy = require('hexy'),
     b = Buffer.from("\000\001\003\005\037\012\011bcdefghijklmnopqrstuvwxyz0123456789")
@@ -16,20 +14,18 @@ var hexy = require('hexy'),
 console.log(hexy.hexy(b))
  ```
 
- results in this dump:
- 
+results in this dump:
+
      00000000: 0001 0305 1f0a 0962 6364 6566 6768 696a  .......bcdefghij
      00000010: 6b6c 6d6e 6f70 7172 7374 7576 7778 797a  klmnopqrstuvwxyz
      00000020: 3031 3233 3435 3637 3839                 0123456789
- 
- but you can configure:
- 
-   * Line numbering
-   * Line width
-   * Format of byte grouping
-   * The case (upper/lower) of hex decimals
-   * Presence of the ASCII annotation in the right column.
- 
+
+you can configure:
+* Line width
+* Format of byte grouping
+* The case (upper/lower) of hex decimals
+* Presence of the ASCII annotation in the right column.
+
  This means it's easy to generate exciting dumps like:
  
      0000000: 0001 0305 1f0a 0962  .... ...b 
@@ -38,97 +34,80 @@ console.log(hexy.hexy(b))
      0000018: 7374 7576 7778 797a  stuv wxyz 
      0000020: 3031 3233 3435 3637  0123 4567 
      0000028: 3839                 89
- 
- or even:
- 
+
+or even:
+
      0000000: 00 01 03 05 1f 0a 09 62   63 64 65 66 67 68 69 6a 
      0000010: 6b 6c 6d 6e 6f 70 71 72   73 74 75 76 77 78 79 7a 
      0000020: 30 31 32 33 34 35 36 37   38 39
+
+## Accepted Input
+The input should be one of the following:
+* a `Buffer`
+* a `String`
+* an `Array` containing `Number`s. These should fit into 8 bits, i.e. be smaller than 255. Larger values are truncated (specifically `val & 0xff`)
  
- with hexy!
- 
- ## Accepted Input
- 
- Currently, input should be one of the following:
- 
-   - a `Buffer`
-   - a `String`
-   - an `Array` containing `Number`s. These should fit into
-     8 bits, i.e. be smaller than 255. Larger values are truncated
-     (specifically `val & 0xff`)
- 
- ## Formatting Options
- 
- Formatting options are configured by passing a `format` object to the `hexy` function:
+## Formatting Options
+Formatting options are configured by passing a `config` object to the `hexy` function:
  
 ```javascript
-var format = {}
-    format.width = width // how many bytes per line, default 16
-    format.numbering = n // ["hex_bytes" | "none"],  default "hex_bytes"
-    format.radix = b     // [2, 8, 10, 16], the radix for numeral representation
-                         // for the right column,    default 16
-    format.format = f    // ["twos"|"fours"|"eights"|"sixteens"|"none"], number of nibbles per group
-                         //                          default "fours"
-    format.littleEndian = true
-                         // endiannes of data,       default false
-                         // counts when number of nibbles is more than "twos",
-                         // i.e. displaying groups bigger than one byte
-    format.extendedChs = true
-                         // allow displaying more characters in the text column
-                         //                          default false
-    format.caps = c      // ["lower"|"upper"],       default lower
-    format.annotate = a  // ["ascii"|"none"], ascii annotation at end of line?
-                         //                          default "ascii"
-    format.prefix = p    // <string> something pretty to put in front of each line
-                         //                          default ""
-    format.indent = i    // <num> number of spaces to indent
-                         //                          default 0
-    format.html = true   // funky html divs 'n stuff! experimental.
-                         //                          default: false
-    format.offset = X    // generate hexdump based on X byte offset
-                         // into the provided source
-                         //                          default 0
-    format.length = Y    // process Y bytes of the provide source 
-                         // starting at `offset`. -1 for all
-                         //                          default -1
-    format.display_offset = Z
-                         // add Z to the address prepended to each line
-                         // (note, even if `offset` is provided, addressing
-                         // is started at 0)
-                         //                          default 0
+var config: {
+    bytesPerLine = 8,   // how many bytes per line, default 16
+    bytesPerGroup = 2,  // how many bytes per group, default 1 (changed in 0.4.0, previously 2)
+    showAddress = true, // show address column on the left, default true
+    radix = b,          // [2, 8, 10, 16], the radix for numeral representation
+                        // for the right column,    default 16
+    littleEndian = true,// endiannes of data,       default false
+                        // counts when number of nibbles is more than "twos",
+                        // i.e. displaying groups bigger than one byte
+    extendedChs = true, // allow displaying more characters in the text column
+                        //                          default false
+    caps = "lower",     // ["lower"|"upper"],       default lower
+    annotate = "ascii", // ["ascii"|"unicode"|"none"], the representation of the text column
+                        //                          default "ascii"
+    prefix = p,         // <string> something pretty to put in front of each line
+                        //                          default ""
+    indent = i,         // <num> number of spaces to indent every output line
+                        //                          default 0
+    html = true,        // funky html divs 'n stuff! experimental.
+                        //                          default: false
+    offset = X,         // generate hexdump based on X byte offset
+                        // into the provided source
+                        //                          default 0
+    length = Y,         // process Y bytes of the provide source 
+                        // starting at `offset`. -1 for all
+                        //                          default -1
+    displayOffset = Z,  // add Z to the address prepended to each line
+                        // (note, even if `offset` is provided, addressing
+                        // is started at 0)
+                        //                          default 0
+};
 
-console.log(hexy.hexy(buffer, format))
+console.log(hexy.hexy(buffer, config));
 ``` 
- In case you're really nerdy, you'll have noticed that the defaults correspond
- to how `xxd` formats its output.
-            
+ In case you're really nerdy, you'll have noticed that the defaults correspond to how `xxd` formats its output.
  
- ## Installing
+## Installing
  
- Either use `npm` (or whatever compatible npm thingie people are using
- these days) :
-   
+Either use `npm` (or whatever compatible npm thingie people are using these days):
 ```shell   
 $ npm install hexy
 ```
 
- This will install the lib which you'll be able to use like so:
-     
+This will install the lib which you'll be able to use like so:
 ```javascript     
 var hexy = require("hexy"),
     buf  = // get Buffer from somewhere,
     str  = hexy.hexy(buf)
- ```
+```
 
- It will also install `hexy` into your path in case you're totally fed up
- with using `xxd`.
-         
-  
- If you don't like `npm`, grab the source from github:
+It will also install `hexy` into your path in case you're totally fed up with using `xxd`.
+
+If you don't like `npm`, grab the source from github:
  
-     http://github.com/a2800276/hexy.js
+    http://github.com/a2800276/hexy.js
  
- ## Typescript
+## Typescript
 
 ```typescript
 import {hexy} from "hexy";
@@ -136,53 +115,47 @@ const buff = ...
 console.log(hexy(buff));
 ```
 
- ## Browser Support
- Browser support is fixed (now supports `Array` and `Uint8Array`) in 0.3.3.
- Please refer to `test.html` for examples.
+## Browser Support
+Browser support is fixed (now supports `Array` and `Uint8Array`) in 0.3.3. Please refer to `test.html` for examples.
  
- ## TODOS
- 
- The current version only pretty prints node.js Buffers, and JS Strings
+# TODOS
+
+The current version only pretty prints node.js Buffers, and JS Strings
  and Arrays. This should be expanded to also do typed arrays,
  Streams/series of Buffers which would be nice so you don't have to
  collect the whole things you want to pretty print in memory, and such.
  
- I'd like to improve html rendering, e.g. to be able to mouse over the
+I'd like to improve html rendering, e.g. to be able to mouse over the
  ascii annotation and highlight the hex byte and vice versa, improve
  browser integration and set up a proper build & packaging system.
 
- Deno support would also be nice.
- 
- **DONE** Better testing for browser use.
- 
+Deno support would also be nice.
   
- ## Thanks
+# Thanks
  
- * Thanks to Isaac Schlueter [isaacs] for gratiously lending a hand and
- cheering me up.
- * dodo (http://coderwall.com/dodo)
- * the fine folks at [Travis](http://travis-ci.org/a2800276/hexy.js)
- * radare (https://github.com/radare)
- * Michele Caini (https://github.com/skypjack)
- * Koen Houtman (https://github.com/automagisch)
- * Stef Levesque (https://github.com/stef-levesque)
- * Abdulaziz Ghuloum (https://github.com/azizghuloum)
+* Thanks to Isaac Schlueter [isaacs] for gratiously lending a hand and cheering me up.
+* dodo (http://coderwall.com/dodo)
+* the fine folks at [Travis](http://travis-ci.org/a2800276/hexy.js)
+* radare (https://github.com/radare)
+* Michele Caini (https://github.com/skypjack)
+* Koen Houtman (https://github.com/automagisch)
+* Stef Levesque (https://github.com/stef-levesque)
+* Abdulaziz Ghuloum (https://github.com/azizghuloum)
+
+# History
  
- ## History
- 
- This is a fairly straightforward port of `hexy.rb` which does more or less the
- same thing. You can find it here: 
+This started a fairly straightforward port of `hexy.rb` which does more or less the same thing. You can find it here:
+
+    http://github.com/a2800276/hexy
   
-     http://github.com/a2800276/hexy
-  
- in case these sorts of things interest you.
+### 0.4.0 (updating the minor version: the API changes, see below)
+* the init parameters no longer contain strings: all params are scalar-defined
+* defaults to single-byte grouping
 
 ### 0.3.4
-
 * issue concerning static analysis and BigInt usage
 
 ### 0.3.3
-
 * introduced the concept of endiannes (googleable and wikiable).  Before this change, the code assumed that the displayed data is big-endian.
     However, most file formats and most CPU architectures are little-endian.  So, introduced the support for it.
     The endiannes can be controlled by passing bool via `littleEndian`, which defaults to `false` to support the behavior of the previous versions
@@ -211,8 +184,7 @@ console.log(hexy(buff));
   * increased formating consistency
 
  ### 0.3.2
- 
- * documentation typos
+  * documentation typos
  * 2FA for npm publish
  
  ### 0.3.1

--- a/bin/hexy_cmd.js
+++ b/bin/hexy_cmd.js
@@ -5,17 +5,20 @@ var hexy = require("../hexy.js"),
 
 function usage(mes) {
   console.log(mes || "usage: " + /[^/\\]*$/.exec(process.argv[1]) + " [options] <filename>");
-  console.log("--width     [(16)]                     how many bytes per line")
-  console.log("--numbering [(hex_bytes)|none]         prefix current byte count")
-  console.log("--radix     [2|8|10|(16)]              radix to use")
-  console.log("--format    [sixteens|eights|(fours)|twos|none] how many nibbles per group")
+  console.log("--bytesPerLine  [(16)]                 number of bytes per line")
+  console.log("--bytesPerGroup [0|(1)|2|4|8]          number of bytes per group")
+  console.log("--showAddress                          display address in the left column")
   console.log("--littleEndian                         the data is littleEndian")
+  console.log("--radix         [2|8|10|(16)]          radix to use")
+  console.log("--caps          [(lower)|upper]        case of hex chars")
+  console.log("--annotate      [(ascii)|none]         display ascii annotation in the right column")
+  console.log("--prefix        [(\"\")|<prefix>]      printed in front of each line")
+  console.log("--indent        [(0)|<num>]            number of spaces to indent output")
+  console.log("--offset        (0)                    number of bytes to skip from the start")
+  console.log("--displayOffset (0)                    shift the address values by this")
+  console.log("--length        (-1) mean all          number of bytes to render")
   console.log("--extendedChs                          show more characters as-is")
-  console.log("--caps      [(lower)|upper]            case of hex chars")
   console.log("--html                                 render the output in HTML format")
-  console.log("--annotate  [(ascii)|none]             provide ascii annotation")
-  console.log("--prefix    [(\"\")|<prefix>]          printed in front of each line")
-  console.log("--indent    [(0)|<num>]                number of spaces to indent output")
   console.log("parameters in (parens) are default")
   process.exit(1)
 }
@@ -31,18 +34,22 @@ function existsFatal(fn) {
 }
 
 function handleArgs () {
-  var format = {},
+  var config = {},
       ARGS = [
-      "--width",
-      "--numbering",
-      "--radix",
-      "--format",
+      "--bytesPerLine",
+      "--bytesPerGroup",
+      "--showAddress",
       "--littleEndian",
-      "--extendedChs",
+      "--radix",
       "--caps",
       "--annotate",
       "--prefix",
       "--indent",
+      "--offset",
+      "--displayOffset",
+      "--length",
+      "--extendedChs",
+      "--html"
       ]
 
   var args = process.argv
@@ -67,14 +74,23 @@ function handleArgs () {
     format[arg] = args[++i]
   }
 
-  if (format.width) {
-    format.width = parseInt(format.width, 10)
+  if (format.bytesPerLine) {
+    format.bytesPerLine = parseInt(format.bytesPerLine, 10)
+  }
+  if (format.bytesPerGroup) {
+    format.bytesPerGroup = parseInt(format.bytesPerGroup, 10)
   }
   if (format.indent) {
     format.indent = parseInt(format.indent, 10)
   }
   if (format.radix) {
     format.radix = parseInt(format.radix, 10)
+  }
+  if (format.offset) {
+    format.offset = parseInt(format.offset, 10)
+  }
+  if (format.displayOffset) {
+    format.displayOffset = parseInt(format.displayOffset, 10)
   }
   if (format.html) {
     format.html = true

--- a/hexy.js
+++ b/hexy.js
@@ -369,7 +369,7 @@ var Hexy = function(buffer, config) {
   var hex = function(buffer, bytes_per_line, bytes_per_group, radix, littleEndian) {
     var str = ""
     const delimiter = bytes_per_group == 0 ? "" : " "
-    const group_len = maxnumberlen(bytes_per_group, radix)
+    var group_len = maxnumberlen(bytes_per_group, radix)  // this changes for the very last group in the file
     const padlen = (bytes_per_line - buffer.length) * (bytes_per_group == 0 ? group_len: (group_len + 1) / bytes_per_group)
     if (bytes_per_group == 0) {
       bytes_per_group = 1
@@ -381,8 +381,11 @@ var Hexy = function(buffer, config) {
       var val = bytes_per_group < 4 ? 0 : BigInt(0)
       for (var ii = start; ii != end; ii += step) {
         const i = group * bytes_per_group + ii
-        if (i >= buffer.length) { // not rendering dangling bytes.  TODO: render them as smaller grouping
-          break
+        if (i >= buffer.length) { // dangling bytes
+          if (radix == 2 || radix == 16) {
+            group_len -= maxnumberlen(1, radix)
+          } // for decimal and octal representation, the length of binary column is difficult to predict
+          continue
         }
         if (bytes_per_group < 4) {
           val = val * 256 + ((buffer.constructor == String ? buffer.codePointAt(i) : buffer[i]) & 0xff)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,20 @@
 
 declare module "hexy" {
   type FormatOptions = {
-    width?: number;
+    bytesPerLine?: number,
+    bytesPerGroup?: number;
+    showAddress?: boolean;
     littleEndian?: boolean;
     radix?: number;
-    numbering?: "hex_bytes" | "none";
-    format?: "eights" | "fours" | "twos" | "none";
     caps?: "lower" | "upper";
     annotate?: "ascii" | "none";
     prefix?: string;
     indent?: number;
-    html?: boolean;
-    extendedChs?: boolean;
     offset?: number;
+    displayOffset?: number;
     length?: number;
-    display_offset?: number;
+    extendedChs?: boolean;
+    html?: boolean;
   }
   export const hexy: (arg: Buffer | string | number[], format?: FormatOptions) => string;
   export const maxnumberlen: (bytes: number, radix: number) => number;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexy",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "hexdump, binary pretty-printing",
   "author": "Tim Becker <tim.becker@kuriositaet.de>",
   "license": "MIT",

--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+const { parseArgs } = require('util');
+
 var hexy = require("./hexy.js")
 const testcases = require("./test/testcases.js")
 
@@ -5,17 +7,30 @@ var testcase_id = [ 0, 0 ] // some tests have multiple variants (distinguished b
 var failed = 0
 var executed = 0
 var iterations = 1
-if (process.argv.includes("perf")) {
+
+var first_testcase_to_exec = 0
+var last_testcase_to_exec = testcases.length
+
+const options = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    perf: { type: 'boolean', short: 'p' },
+    baseline: { type: 'boolean', short: 'b' },
+    single: { type: 'string', short: 't' },
+    verbose: { type: 'boolean', short: 'v' }
+  }  
+})
+
+if (options.values.perf) {
   iterations = 100000
 }
-var execute_first_X_tests = null
-if (process.argv.includes("baseline")) { // baselining against version 0.3.2, which 
-  execute_first_X_tests = 29             // had 29 test lines (65 testcases total), that
-}                                        // are preserved at the top of the list of tests
-var verbose = false
-if (process.argv.includes("-v")) {
-  verbose = true
+if (options.values.single !== undefined ) {
+  first_testcase_to_exec = parseInt(options.values.single)
+  last_testcase_to_exec = first_testcase_to_exec + 1
 }
+if (options.values.baseline) {           // baselining against version 0.3.2, which 
+  last_testcase_to_exec = 29             // had 29 test lines (65 testcases total), that
+}                                        // are preserved at the top of the list of tests
 
 function check(should, is) {
   if (should !== is) {
@@ -29,24 +44,30 @@ function check(should, is) {
     console.log("more detailed view of ACTUALLY RETURNED:")
     console.log(hexy.hexy(is))
     failed++
-  } else if (verbose) {
+  } else if (options.values.verbose) {
+    console.log("\x1b[32m       SUCCEEDED testcase # " + testcase_id + "\x1b[0m")
     console.log(is)
   }
   executed++
 }
 
 for (var rep = 0; rep < iterations; rep++) {
-  for (var tc = 0; tc < (execute_first_X_tests || testcases.length); tc++) {
+  for (var tc = first_testcase_to_exec; tc < last_testcase_to_exec; tc++) {
     if ('inputs' in testcases[tc]) {
       for (var ii = 0; ii < testcases[tc].inputs.length; ii++) {
         testcase_id = [tc, ii]
-        check(testcases[tc].result, hexy.hexy(testcases[tc].inputs[ii], testcases[tc].params))
+        check(testcases[tc].result, hexy.hexy(testcases[tc].inputs[ii], testcases[tc].config))
       }
     } else {
       testcase_id = tc
-      check(testcases[tc].result, hexy.hexy(testcases[tc].input, testcases[tc].params))
+      check(testcases[tc].result, hexy.hexy(testcases[tc].input, testcases[tc].config))
     }
   }
+}
+
+console.log("Executed: " + executed + ", Failed: " + failed)
+if (iterations > 1) {
+  console.log("This was a perf run over " + iterations + " iterations")
 }
 
 function checkVersion () {
@@ -54,14 +75,13 @@ function checkVersion () {
   const pkg = fs.readFileSync("package.json") 
   const version = JSON.parse(pkg).version
 
-  check(version, hexy.Hexy.VERSION)
+  if (version !== hexy.Hexy.VERSION) {
+    console.log("\x1b[31m       FAILED: the version in package.json and in the code do not match\x1b[0m")
+    failed++
+  }
 }
-checkVersion()
 
-console.log("Executed: " + executed + ", Failed: " + failed)
-if (iterations > 1) {
-  console.log("This was a perf run over " + iterations + " iterations")
-}
+checkVersion()
 
 if (failed != 0) {
   process.exit(1)

--- a/test/testcases.js
+++ b/test/testcases.js
@@ -145,6 +145,8 @@ const testcases = [
 // #30
   { input: [ 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xd2, 0x77, 0x6f, 0x72, 0x6c, 0x64 ], params: {format: "twos"}, result: "00000000: 68 65 6c 6c 6f d2 77 6f 72 6c 64                   hello.world\n" },
   { input: [ 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xd2, 0x77, 0x6f, 0x72, 0x6c, 0x64 ], params: {format: "twos", extendedChs:true}, result: "00000000: 68 65 6c 6c 6f d2 77 6f 72 6c 64                   hello" + "\u00d2" + "world\n" },
+  { input: "abc", params: {littleEndian: true}, result: "00000000: 6261 63                                  abc\n" },
+  { input: "abc", params: {littleEndian: true, format: "eights"}, result: "00000000: 636261                               abc\n" },
 ];
 if (typeof window === 'undefined') {
   module.exports = testcases;

--- a/test/testcases.js
+++ b/test/testcases.js
@@ -99,54 +99,75 @@ const results = [
 
 const testcases = [
 // #0
-  { input: str, params: {}, result: results[0] }, // historic first testcase will always remain #0
-  { inputs: bundle, params: {}, result: results[0] },
-  { inputs: bundle, params: {caps:"upper"}, result: results[1] },
-  { inputs: bundle, params: {width:8}, result: results[2] },
-  { inputs: bundle, params: {width:8, caps:"upper"}, result: results[3] },
-  { inputs: bundle, params: {numbering:"none"}, result: results[4] },
-  { inputs: bundle, params: {format:"twos"}, result: results[5] },
-  { inputs: bundle, params: {format:"eights"}, result: results[6] },
-  { inputs: bundle, params: {format:"none"}, result: results[7] },
-  { inputs: bundle, params: {annotate:"none"}, result: results[8] },
+  { input: str, config: { bytesPerGroup: 2 }, result: results[0] }, // historic first testcase will always remain #0
+  { inputs: bundle, config: { bytesPerGroup: 2, }, result: results[0] },
+  { inputs: bundle, config: { bytesPerGroup: 2, caps: "upper" }, result: results[1] },
+  { inputs: bundle, config: { bytesPerGroup: 2, bytesPerLine: 8 }, result: results[2] },
+  { inputs: bundle, config: { bytesPerGroup: 2, bytesPerLine: 8, caps:"upper" }, result: results[3] },
+  { inputs: bundle, config: { bytesPerGroup: 2, showAddress: false }, result: results[4] },
+  { inputs: bundle, config: { bytesPerGroup: 1 }, result: results[5] },
+  { inputs: bundle, config: { bytesPerGroup: 4 }, result: results[6] },
+  { inputs: bundle, config: { bytesPerGroup: 0 }, result: results[7] },    // bytesPerGroup === 0 means there's no spaces between hex nibbles
+  { inputs: bundle, config: { bytesPerGroup: 2, annotate: "none" }, result: results[8] },
 // #10
-  { inputs: bundle, params: {prefix:"-"}, result: results[9] },
-  { inputs: bundle, params: {indent:"5"}, result: results[10] },
-  { inputs: bundle, params: {caps:"upper", numbering:"none", annotate:"none", prefix:"dingdong", format:"twos"}, result: results[11] },
-  { inputs: bundle, params: {html:true}, result: results[12] },
-  { inputs: bundle, params: {offset:10}, result: results[13] },
-  { inputs: bundle, params: {offset:10, length:10}, result: results[14] },
-  { inputs: bundle, params: {offset:10, length:10, html:true}, result: results[15] },
-  { inputs: bundle, params: {display_offset:10}, result: results[16] },
-  { inputs: bundle, params: {display_offset:10, offset:10, length:10}, result: results[17] },
-  { input: _00 + _00 + _08 + _40 + _53 + _00 + _0000 + _5100 + _0000 + _5100 + _0000, params: {}, result: "00000000: 0000 0840 5300 0000 5100 0000 5100 0000  ...@S...Q...Q...\n" },
+  { inputs: bundle, config: { bytesPerGroup: 2, prefix: "-" }, result: results[9] },
+  { inputs: bundle, config: { bytesPerGroup: 2, indent: 5 }, result: results[10] },
+  { inputs: bundle, config: { bytesPerGroup: 2, caps: "upper", showAddress: false, annotate: "none", prefix: "dingdong", bytesPerGroup: 1 }, result: results[11] },
+  { inputs: bundle, config: { bytesPerGroup: 2, html: true }, result: results[12] },
+  { inputs: bundle, config: { bytesPerGroup: 2, offset: 10 }, result: results[13] },
+  { inputs: bundle, config: { bytesPerGroup: 2, offset: 10, length: 10 }, result: results[14] },
+  { inputs: bundle, config: { bytesPerGroup: 2, offset: 10, length: 10, html: true }, result: results[15] },
+  { inputs: bundle, config: { bytesPerGroup: 2, displayOffset: 10 }, result: results[16] },
+  { inputs: bundle, config: { bytesPerGroup: 2, displayOffset: 10, offset: 10, length: 10 }, result: results[17] },
+  { input: _00 + _00 + _08 + _40 + _53 + _00 + _0000 + _5100 + _0000 + _5100 + _0000, config: { bytesPerGroup: 2 }, result: "00000000: 0000 0840 5300 0000 5100 0000 5100 0000  ...@S...Q...Q...\n" },
 // #20
-  { input: str3, params: {}, result: "00000000: 2369 6e63 6c75 6465 3c73 7464 696f 2e68  #include<stdio.h\n00000010: 3e0a                                     >.\n" },
-  { input: str3, params: {html:true}, result: "<div class='hexy'>\n"+
+  { input: str3, config: { bytesPerGroup: 2 }, result: "00000000: 2369 6e63 6c75 6465 3c73 7464 696f 2e68  #include<stdio.h\n00000010: 3e0a                                     >.\n" },
+  { input: str3, config: { bytesPerGroup: 2, html:true }, result: "<div class='hexy'>\n"+
                                               "<div class='00000000 even'>00000000: 2369 6e63 6c75 6465 3c73 7464 696f 2e68  #include&lt;stdio.h</div>\n"+
                                               "<div class='00000010  odd'>00000010: 3e0a &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &gt;.</div>\n"+
                                               "</div>\n" },
-  // empties
-  { input: "", params: {}, result: "" },
   // Number arrays with bytes work, arrays containing values larger that 0xff are truncated ( val & 0xff )
-  { input: arr, params: {}, result: arr_e },
-   // non numerical width
-  { input: arr, params: {width: "something"}, result: arr_e },
-  { input: arr, params: {width: "2"}, result: "00000000: 0102  ..\n00000002: 030f  ..\n" },
-  { input: arr, params: {width: 1}, result: "00000000: 01  .\n00000001: 02  .\n00000002: 03  .\n00000003: 0f  .\n" },
+  { input: arr, config: { bytesPerGroup: 2}, result: arr_e },
+   // non numerical bytesPerLine
+  { input: arr, config: { bytesPerLine: "something" }, result: "00000000: 01 02 03 0f                                        ....\n" },
+  { input: arr, config: { bytesPerLine: 2, bytesPerGroup: 2 }, result: "00000000: 0102  ..\n00000002: 030f  ..\n" },
+  { input: arr, config: { bytesPerGroup: 2, bytesPerLine: 1 }, result: "00000000: 01  .\n00000001: 02  .\n00000002: 03  .\n00000003: 0f  .\n" },
   // endianness
-  { input: arr, params: {littleEndian: true}, result: "00000000: 0201 0f03                                ....\n" },
+  { input: arr, config: { bytesPerGroup: 2, littleEndian: true }, result: "00000000: 0201 0f03                                ....\n" },
   // alternative radix
-  { input: arr, params: {radix: 10, format: "twos"}, result: "00000000: 001 002 003 015                                                    ....\n" },
+  { input: arr, config: { radix: 10, bytesPerGroup: 1 }, result: "00000000: 001 002 003 015                                                    ....\n" },
   // suppression of non-printable characters
-  { input: [ 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xd2, 0x77, 0x6f, 0x72, 0x6c, 0x64 ], params: {format: "twos", html: true, extendedChs: true}, result: "<div class='hexy'>\n"+
-                                                                                                                                                  "<div class='00000000 even'>00000000: 68 65 6c 6c 6f d2 77 6f 72 6c 64 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; hello&#xd2;world</div>\n"+
-                                                                                                                                                  "</div>\n" },
+  { input: [ 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xd2, 0x77, 0x6f, 0x72, 0x6c, 0x64 ], config: { bytesPerGroup: 1, html: true, extendedChs: true }, result: "<div class='hexy'>\n"+
+                                                                                                                                                      "<div class='00000000 even'>00000000: 68 65 6c 6c 6f d2 77 6f 72 6c 64 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; hello&#xd2;world</div>\n"+
+
+                                                                                                                                                      "</div>\n" },
 // #30
-  { input: [ 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xd2, 0x77, 0x6f, 0x72, 0x6c, 0x64 ], params: {format: "twos"}, result: "00000000: 68 65 6c 6c 6f d2 77 6f 72 6c 64                   hello.world\n" },
-  { input: [ 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xd2, 0x77, 0x6f, 0x72, 0x6c, 0x64 ], params: {format: "twos", extendedChs:true}, result: "00000000: 68 65 6c 6c 6f d2 77 6f 72 6c 64                   hello" + "\u00d2" + "world\n" },
-  { input: "abc", params: {littleEndian: true}, result: "00000000: 6261 63                                  abc\n" },
-  { input: "abc", params: {littleEndian: true, format: "eights"}, result: "00000000: 636261                               abc\n" },
+  { input: [], config: {}, result: "" },
+  { input: null, config: {}, result: "" },
+  { input: "", config: {}, result: "" },
+  { input: undefined, config: {}, result: "" },
+  { input: [0x41], config: { bytesPerGroup: 2 }, result: "00000000: 41                                       A\n" },
+  { input: "A", config: {}, result: "00000000: 41                                                 A\n" },
+  { input: "😀", config: { bytesPerGroup: 2 }, result: "00000000: f09f 9880                                ....\n" },
+  { input: "-\u{1d11e}+" /*𝄞*/, config: { bytesPerGroup: 1 }, result: "00000000: 2d f0 9d 84 9e 2b                                  -....+\n" },
+  { input: new Uint8Array([0x41, 0x42, 0x43]), config: { bytesPerGroup: 2 }, result: "00000000: 4142 43                                  ABC\n" },
+  { input: [0x123, 0x456], config: { bytesPerGroup: 2 }, result: "00000000: 2356                                     #V\n" },
+  { input: [-1, 0, 255], config: { bytesPerGroup: 2 }, result: "00000000: ff00 ff                                  ...\n" },
+// #40
+  { input: [1,2,3], config: { offset: 10 }, result: "0000000a: 01 02 03                                           ...\n" },
+  { input: [1,2,3], config: { bytesPerGroup: 2, length: 10 }, result: "00000000: 0102 03                                  ...\n" },
+  { input: [1,2,3], config: { bytesPerGroup: 2, offset: -1 }, result: "000000-1: 03                                       .\n" },
+  { input: [1,2,3], config: { bytesPerGroup: 2, length: -5 }, result: "" },
+  { input: "<>&'\"", config: { bytesPerGroup: 2, html: true, extendedChs: true }, result: "<div class='hexy'>\n<div class='00000000 even'>00000000: 3c3e 2627 22 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &lt;&gt;&amp;&apos;&quot;</div>\n</div>\n" },
+  { input: [0x61, 0x62, 0x63], config: { radix: 8, caps: "upper", showAddress: false, bytesPerGroup: 1, html: false, prefix: ">", indent: 2 }, result: "  >141 142 143                                                        abc\n" },
+  { input: [0x61, 0x62], config: { prefix: 123, indent: 3 }, result: "   12300000000: 61 62                                              ab\n" },
+  { input: new ArrayBuffer(4), config: {}, result: "" },
+  { input: [ 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xd2, 0x77, 0x6f, 0x72, 0x6c, 0x64 ], config: { bytesPerGroup: 1 }, result: "00000000: 68 65 6c 6c 6f d2 77 6f 72 6c 64                   hello.world\n" },
+  { input: [ 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xd2, 0x77, 0x6f, 0x72, 0x6c, 0x64 ], config: { bytesPerGroup: 1, extendedChs: true }, result: "00000000: 68 65 6c 6c 6f d2 77 6f 72 6c 64                   hello" + "\u00d2" + "world\n" },
+// #50
+  { input: "abc", config: { bytesPerGroup: 2, littleEndian: true }, result: "00000000: 6261 63                                  abc\n" },
+  { input: "abc", config: { bytesPerGroup: 4, littleEndian: true }, result: "00000000: 636261                               abc\n" },
+
 ];
 if (typeof window === 'undefined') {
   module.exports = testcases;

--- a/view.html
+++ b/view.html
@@ -152,7 +152,7 @@
   </header>
 
   <section>
-    <textarea cols='80' class='hexdata'></textarea>
+    <textarea cols='80' class='hexdata' spellcheck='false'></textarea>
   </section>
 
   <footer>

--- a/view.html
+++ b/view.html
@@ -36,53 +36,207 @@
       margin: 0;
       font-family: monospace;
     }
+    .hex-scroll-outer {
+      position: relative;
+      height: 100%;
+      width: 100%;
+      overflow-y: scroll;
+      font-family: monospace;
+      background: #222;
+      color: #eee;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+    }
+    .hex-scroll-spacer {
+      width: 1px;
+    }
+    .hex-viewport {
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      min-width: 0;
+      pointer-events: auto;
+      white-space: pre;
+      font-family: inherit;
+      color: inherit;
+      user-select: text;
+      -webkit-user-select: text;
+      -moz-user-select: text;
+      -ms-user-select: text;
+    }
   </style>
-  <script src="hexy.js"></script>
-  <script src="test/testcases.js"></script>
-  <script type="text/javascript">
-    var current_file = null;
+<script src="hexy.js"></script>
+<script type="text/javascript">
+  var current_file = null;
+  var file_array = null;
+  var fmt = null;
+  var lineHeight = 18; // px, must match CSS/JS
+  let selectionAnchorOffset = null;
+  let selectionFocusOffset = null;
 
-    function readFile() {
-      current_file = event.target.files[0];
-      hexdata = document.querySelector(".hexdata");
+  function readFile() {
+    current_file = event.target.files[0];
+    const reader = new FileReader();
+    reader.onload = function() {
+      file_array = new Uint8Array(reader.result);
       update();
-    }
+    };
+    reader.readAsArrayBuffer(current_file);
+  }
 
-    function update() {
-      const fmt = {
-        numbering:    document.getElementById('address').checked ? 'hex_bytes' : 'none',
-        format:       document.querySelector('input[name="format"]:checked').value,
-        littleEndian: document.querySelector('input[name="littleEndian"]:checked').value === 'true',
-        radix:        parseInt(document.querySelector('input[name="radix"]:checked').value),
-        caps:         document.getElementById('caps').checked ? 'upper' : 'lower',
-        html:         document.getElementById('html').checked,
-        extendedChs:  document.getElementById('extendedChs').checked,
-      };
-      console.log(fmt);
-      const reader = new FileReader();
-      reader.onload = function() {
-        const data = reader.result;
-        const array = new Uint8Array(data);
-        hexdata.rows = (array.length + 15) / 16;
-        hexdata.value = hexy(array, fmt);
-      };
-      reader.readAsArrayBuffer(current_file);
-    }
+  function getFormat() {
+    return {
+      bytesPerLine: 16,
+      bytesPerGroup: parseInt(document.querySelector('input[name="format"]:checked').value),
+      showAddress:  document.getElementById('address').checked,
+      littleEndian: document.querySelector('input[name="littleEndian"]:checked').value === 'true',
+      radix:        parseInt(document.querySelector('input[name="radix"]:checked').value),
+      caps:         document.getElementById('caps').checked ? 'upper' : 'lower',
+      html:         false,
+      extendedChs:  document.getElementById('extendedChs').checked,
+    };
+  }
 
-    function pageResized() {
-      const header = document.getElementsByTagName('header')[0];
-      const footer = document.getElementsByTagName('footer')[0];
-      const section = document.getElementsByTagName('section')[0];
-      section.style.height = (window.innerHeight - header.offsetHeight - footer.offsetHeight) + "px";
+  function update() {
+    fmt = getFormat();
+    const outer = document.querySelector(".hex-scroll-outer");
+    const viewport = document.querySelector(".hex-viewport");
+    const spacer = document.querySelector(".hex-scroll-spacer");
+    if (!file_array) {
+      viewport.textContent = "";
+      spacer.style.height = "0px";
+      return;
     }
+    const bytesPerLine = fmt.bytesPerLine || 16;
+    const totalLines = Math.ceil(file_array.length / bytesPerLine);
+    spacer.style.height = (totalLines * lineHeight) + "px";
+    renderVisible();
+  }
 
-    function pageLoaded() {
-      pageResized();
-      const inputs = document.getElementsByTagName('input');
-      for (var ii = 0; ii < inputs.length; ii++) {
-        inputs[ii].addEventListener("change", update);
+  // converts cursor position to address within the viewed file of the cursor position
+  // `hex_pos`: character offset in the hex rendering
+  // return: byte offset in the file
+  function hex2file(hex_pos) {
+    const fmt = getFormat();
+    const blank = Array(fmt.bytesPerLine).fill(" ");
+    const lineLengthInChars = hexy(blank, {
+        ...fmt,
+        displayOffset: 0,
+      }).length;
+
+    const result = {
+      line: Math.floor(hex_pos / lineLengthInChars),
+      x: Math.floor(hex_pos % lineLengthInChars)
+    };
+    return result;
+  }
+
+  function file2hex(file_pos) {
+    const fmt = getFormat();
+    const blank = Array(fmt.bytesPerLine).fill(" ");
+    const lineLengthInChars = hexy(blank, {
+        ...fmt,
+        displayOffset: 0,
+      }).length;
+    return file_pos.line * lineLengthInChars + file_pos.x;
+  }
+
+  var _startLine = 0;   // the line displayed on top of the window
+
+  function saveSelections() {
+    const fmt = getFormat();
+    const viewport = document.querySelector(".hex-viewport");
+    const selection = window.getSelection();
+    const blank = Array(fmt.bytesPerLine).fill(" ");
+    const selections = [];
+    for (var rr = 0; rr < selection.rangeCount; rr++) {
+      const char_selection = selection.getRangeAt(rr);
+      var range = {};
+      range.start = hex2file(char_selection.startOffset);
+      range.start.line += _startLine;
+      range.end = hex2file(char_selection.endOffset);
+      range.end.line += _startLine;
+      selections.push(range);
+    }
+    return selections;
+  }
+
+  function restoreSelections(selections) {
+    const fmt = getFormat();
+    const blank = Array(fmt.bytesPerLine).fill(" ");
+    const lineLengthInChars = hexy(blank, {
+        ...fmt,
+        displayOffset: 0,
+      }).length;
+    const viewport = document.querySelector(".hex-viewport");
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    for (var ss = 0; ss < selections.length; ss++) {
+      try {
+        var selection = selections[ss];
+        const range = document.createRange();
+        selection.start.line -= _startLine;
+        if (selection.start.line < 0) {
+          selection.start.line = 0;
+        }
+        selection.end.line -= _startLine;
+        if (selection.end.line > 0) {
+          range.setStart(viewport.firstChild, file2hex(selection.start));
+          range.setEnd(viewport.firstChild, file2hex(selection.end));
+          sel.addRange(range);
+        }
+      } catch (e) {
+        console.error(e);
       }
     }
+  }
+
+  function renderVisible() {
+    if (!file_array) return;
+    const outer = document.querySelector(".hex-scroll-outer");
+    const viewport = document.querySelector(".hex-viewport");
+    const bytesPerLine = fmt.bytesPerLine || 16;
+    const totalLines = Math.ceil(file_array.length / bytesPerLine);
+    const scrollTop = outer.scrollTop;
+    const containerHeight = outer.clientHeight;
+    const startLine = Math.floor(scrollTop / lineHeight);
+    const linesPerPage = Math.ceil(containerHeight / lineHeight) + 2;
+    const endLine = Math.min(_startLine + linesPerPage, totalLines);
+
+    const selections = saveSelections();
+
+    _startLine = startLine;
+
+    let out = "";
+    for (let line = _startLine; line < endLine; ++line) {
+      const start = line * bytesPerLine;
+      const end = Math.min(start + bytesPerLine, file_array.length);
+      const slice = file_array.slice(start, end);
+      out += hexy(slice, {
+        ...fmt,
+        displayOffset: (fmt.displayOffset || 0) + start,
+      });
+    }
+    viewport.textContent = out;
+    viewport.style.top = (_startLine * lineHeight) + "px";
+
+    restoreSelections(selections);
+  }
+
+  function pageResized() {
+    update();
+  }
+
+  function pageLoaded() {
+    pageResized();
+    const inputs = document.getElementsByTagName('input');
+    for (var ii = 0; ii < inputs.length; ii++) {
+      inputs[ii].addEventListener("change", update);
+    }
+    document.querySelector(".hex-scroll-outer").addEventListener("scroll", renderVisible);
+    window.addEventListener("resize", pageResized);
+  }
 </script>
 </head>
 
@@ -97,15 +251,15 @@
 
     <fieldset class='box'>
       <legend>bytes in group</legend>
-      <div class='bytesingroup'>
-        <input type='radio' id='twos' name='format' value='twos' checked>
-        <label for='twos'>1</label><br>
-        <input type='radio' id='fours' name='format' value='fours'>
-        <label for='fours'>2</label><br>
-        <input type='radio' id='eights' name='format' value='eights'>
-        <label for='eights'>4</label><br>
-        <input type='radio' id='sixteens' name='format' value='sixteens'>
-        <label for='sixteens'>8</label><br>
+      <div class='bytesPerGroup'>
+        <input type='radio' id='bpg_1' name='format' value='1' checked>
+        <label for='pbg_1'>1</label><br>
+        <input type='radio' id='bpg_2' name='format' value='2'>
+        <label for='bpg_2'>2</label><br>
+        <input type='radio' id='bpg_4' name='format' value='4'>
+        <label for='pbg_4'>4</label><br>
+        <input type='radio' id='bpg_8' name='format' value='8'>
+        <label for='bpg_8'>8</label><br>
       </div>
     </fieldset>
 
@@ -151,8 +305,11 @@
     </fieldset>
   </header>
 
-  <section>
-    <textarea cols='80' class='hexdata' spellcheck='false'></textarea>
+  <section style="height:calc(100vh - 120px);">
+    <div class="hex-scroll-outer">
+      <div class="hex-scroll-spacer"></div>
+      <div class="hex-viewport"></div>
+    </div>
   </section>
 
   <footer>


### PR DESCRIPTION
Yeah, sorry about that.  This change fixes for the case of base-16 (hex) and base-2 (binary).  Doesn't address for the decimal and octal cases, since the line length changes depending on content.